### PR TITLE
Update gdal import for new bindings syntax

### DIFF
--- a/nodes/mbes_sim_node.py
+++ b/nodes/mbes_sim_node.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import gdal
+from osgeo import gdal
 import sys
 import rospy
 from geographic_msgs.msg import GeoPointStamped


### PR DESCRIPTION
As I'm setting up a new dev. environment the gdal version from Ubuntu apt repos is 3.2.1. The import gdal appears to be no longer supported in favor of the new syntax - see https://pypi.org/project/GDAL/